### PR TITLE
Don't throw an error when the argument type to escape_html is not a String

### DIFF
--- a/ext/hescape/hescape.c
+++ b/ext/hescape/hescape.c
@@ -171,7 +171,6 @@ rb_escape_html(RB_UNUSED_VAR(VALUE self), VALUE value)
   unsigned int size;
   VALUE str;
 
-  Check_Type(value, T_STRING);
   str = rb_convert_type(value, T_STRING, "String", "to_s");
 
   size = hesc_escape_html(&buf, RSTRING_PTR(str), RSTRING_LEN(str));


### PR DESCRIPTION
The next line converts the argument to a string so forcing the argument to be a string seems unnecessary.